### PR TITLE
Don't unwrap Int, Float and Bool in Parser

### DIFF
--- a/Sources/language/Ast.swift
+++ b/Sources/language/Ast.swift
@@ -135,10 +135,10 @@ public func == (lhs: FragmentDefinition, rhs: FragmentDefinition) -> Bool {
 
 public indirect enum Value: Node {
   case VariableValue(Variable)
-  case IntValue(Int)
-  case FloatValue(Float)
+  case IntValue(String)
+  case FloatValue(String)
   case StringValue(String)
-  case BoolValue(Bool)
+  case BoolValue(String)
   case Enum(String)
   case List([Value])
   case Object([ObjectField])

--- a/Sources/language/Parser.swift
+++ b/Sources/language/Parser.swift
@@ -10,8 +10,6 @@ enum ParserError: ErrorType {
   case UnexpectedToken(Token)
   case UnexpectedKeyword(Keyword, Token)
   case WrongTokenKind(TokenKind, TokenKind)
-  case InvalidIntLiteral(String?)
-  case InvalidFloatLiteral(String?)
 }
 
 public class Parser {
@@ -115,7 +113,7 @@ extension Parser {
     return peek(.Spread) ? try parseFragment() : Selection.FieldSelection(try parseField())
   }
 
-  private func parseField() throws -> Field{
+  private func parseField() throws -> Field {
     let nameOrAlias = try parseName()
     let alias: Name?
     let name: Name
@@ -205,17 +203,17 @@ extension Parser {
     case .BraceL:
       return try parseObject(isConst: isConst)
     case .Int:
-      guard let value = token.value, let intValue = Int(value) else {
-        throw ParserError.InvalidIntLiteral(token.value)
+      guard let value = token.value else {
+        throw ParserError.UnexpectedToken(token)
       }
       try advance()
-      return .IntValue(intValue)
+      return .IntValue(value)
     case .Float:
-      guard let value = token.value, let floatValue = Float(value) else {
-        throw ParserError.InvalidFloatLiteral(token.value)
+      guard let value = token.value else {
+        throw ParserError.UnexpectedToken(token)
       }
       try advance()
-      return .FloatValue(floatValue)
+      return .FloatValue(value)
     case .String:
       guard let value = token.value else {
         throw ParserError.UnexpectedToken(token)
@@ -223,10 +221,9 @@ extension Parser {
       try advance()
     return .StringValue(value)
     case .Name:
-      if (token.value == Keyword.boolFalse.rawValue || token.value == Keyword.boolTrue.rawValue) {
-        let value = token.value
+      if let value = token.value where (value == Keyword.boolFalse.rawValue || value == Keyword.boolTrue.rawValue) {
         try advance()
-        return .BoolValue(value == Keyword.boolTrue.rawValue)
+        return .BoolValue(value)
       } else if (token.value != Keyword.null.rawValue) {
         guard let value = token.value else {
           throw ParserError.UnexpectedToken(token)

--- a/Tests/language/ParserTests.swift
+++ b/Tests/language/ParserTests.swift
@@ -20,7 +20,7 @@ class ParserTests: XCTestCase {
     XCTAssertEqual(ast,
       Document(definitions: [
         .Operation(OperationDefinition(type: .query, name: nil, variableDefinitions: [], directives: [], selectionSet: SelectionSet(selections: [
-          .FieldSelection(Field(alias: nil, name: Name(value: "node"), arguments: [Argument(name: Name(value: "id"), value: .IntValue(4))], directives: [], selectionSet: SelectionSet(selections: [
+          .FieldSelection(Field(alias: nil, name: Name(value: "node"), arguments: [Argument(name: Name(value: "id"), value: .IntValue("4"))], directives: [], selectionSet: SelectionSet(selections: [
             .FieldSelection(Field(alias: nil, name: Name(value: "id"), arguments: [], directives: [], selectionSet: nil)),
             .FieldSelection(Field(alias: nil, name: Name(value: "name"), arguments: [], directives: [], selectionSet: nil))
           ])))


### PR DESCRIPTION
🚧 

We'll let the validation step do that.